### PR TITLE
Use map stream directly instead of es.map.

### DIFF
--- a/gulp-livereload.js
+++ b/gulp-livereload.js
@@ -1,5 +1,5 @@
 module.exports = function (server) {
-  var es = require('event-stream');
+  var map = require('map-stream');
 
   var changed = function (file, cb) {
     server.changed({
@@ -11,5 +11,5 @@ module.exports = function (server) {
     cb(null, file);
   };
 
-  return es.map(changed);
+  return map(changed);
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "event-stream": "~3.0.20"
+    "map-stream": "~0.1.0"
   },
   "keywords": [
     "gulpplugin",


### PR DESCRIPTION
Refactored this as the plugin doesn't need all of event stream.
