### PR TITLE
Support for port number as input

### DIFF
--- a/gulp-livereload.js
+++ b/gulp-livereload.js
@@ -7,7 +7,12 @@ module.exports = exports = function (server) {
       tinylr = require('tiny-lr'),
       Transform = require('stream').Transform,
       reload = new Transform({objectMode:true}),
-      magenta = gutil.colors.magenta;
+      magenta = gutil.colors.magenta,
+      defaultPort = 35729;
+
+  if (typeof server === 'undefined') {
+    server = defaultPort;
+  }
 
   if (typeof server === 'number') {
     var port = server;

--- a/test/greload.js
+++ b/test/greload.js
@@ -26,8 +26,22 @@ describe('gulp-livereload', function() {
     });
   });
   it('reloads file passing a port number', function(done) {
-    var port = 35729;
+    var port = 35730;
     var reload = greload(port);
+    var spy = sinon.spy(greload.servers[port], 'changed');
+    reload.end(file);
+    reload.on('data', function(file) {
+      should(spy.calledWith({
+        body: {
+          files: [file.path]
+        }
+      })).ok;
+      done();
+    });
+  });
+  it('reloads file using default port if given no parameter at all', function(done) {
+    var reload = greload();
+    var port = 35729;
     var spy = sinon.spy(greload.servers[port], 'changed');
     reload.end(file);
     reload.on('data', function(file) {
@@ -41,7 +55,7 @@ describe('gulp-livereload', function() {
   });
   it('throws an error if neither a livereload server nor a port number was passed', function() {
     should(function() {
-      var reload = greload();
+      var reload = greload([]);
     }).throw('Please pass a port number or an instance of tiny-lr when calling gulp-livereload.');
   });
 });


### PR DESCRIPTION
This adds support for taking a port number as input to the `gulp-livereload` plugin. It then creates a `tiny-lr` server that listens on the given port. It even supports taking no parameters, with fallback to default port number for livereload.

**Example:**

```
var reload = require('gulp-livereload');

gulp.src('./dir/file.type')
  .pipe(reload(35729))
// or:
  .pipe(reload());
```

What do you think?
