### PR TITLE
expose tinylr so you can use its middleware

### DIFF
--- a/gulp-livereload.js
+++ b/gulp-livereload.js
@@ -4,7 +4,7 @@ module.exports = exports = function (server) {
 
   var gutil = require('gulp-util'),
       path = require('path'),
-      tinylr = require('tiny-lr-fork'),
+      tinylr = exports.tinylr = require('tiny-lr-fork'),
       Transform = require('stream').Transform,
       reload = new Transform({objectMode:true}),
       magenta = gutil.colors.magenta,


### PR DESCRIPTION
there is a rather popular task for static or dynamic web server, so sometimes it's useful to write something like 

``` javascript
gulp.task('server', function (cb) {
    try { var app = require('./backend/index');} 
    catch (e) {var app = connect();}
    app = app.use('/', connect.static('dist'))
        .use('/', lr.tinylr.middleware({app: app}));
    require('http').createServer(app).listen(3000, cb);
});
```
