### PR TITLE
New "basePath" option

### DIFF
--- a/gulp-livereload.js
+++ b/gulp-livereload.js
@@ -88,7 +88,7 @@ exports.changed = function(filePath, server) {
   server = exports.listen(server);
   filePath = (filePath) ? filePath.hasOwnProperty('path') ? filePath.path : filePath : '*';
 
-  if (exports.options.basePath !== null) {
+  if (exports.options.basePath) {
     filePath = '/' + path.relative(exports.options.basePath, filePath);
   }
 


### PR DESCRIPTION
Currently, gulp-livereload sends the full path of changed files to tiny-lr. Example:

```
/home/username/projects/project_name/css/main.css
```

It would be better to just send the path relative to the project directory:

```
/css/main.css
```

For two reasons:
1. Leaking the full path could be considered a (very) minor security issue.
2. Enable a stricter path matching in the client-side livereload.js file.

The patch implements a new "basePath" option. Usage in gulpfile.js:

```
livereload.listen(35729, {basePath: process.cwd()});
```

(This example assumes that gulpfile.js exists in the project root. If not you may have to append "htdocs" or manually specify a path.)
