### PR TITLE
Fix livereload for npm v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ You can also tell the browser to refresh the entire page. This assumes the page 
 
 ###  livereload.middleware
 
-You can also directly access the middleware of the underlying server instance (tiny-lr.middleware) for hookup through express, connect, or some other middleware app
+You can also directly access the middleware of the underlying server instance (mini-lr.middleware) for hookup through express, connect, or some other middleware app
 
 ### livereload.server
 
-gulp-livereload also reveals the underlying server instance for direct access if needed. The instance is a "tiny-lr" instance that this wraps around. If the server is not running then this will be `undefined`.
+gulp-livereload also reveals the underlying server instance for direct access if needed. The instance is a "mini-lr" instance that this wraps around. If the server is not running then this will be `undefined`.
 
 Debugging
 ---

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var es = require('event-stream');
-var tinylr = require('tiny-lr');
+var minilr = require('mini-lr');
 var relative = require('path').relative;
 var _assign = require('lodash.assign');
 var debug = require('debug')('gulp:livereload');
@@ -63,7 +63,7 @@ exports.server = undefined;
  * A direct reference to the underlying servers middleware reference
  */
 
-exports.middleware = tinylr.middleware;
+exports.middleware = minilr.middleware;
 
 /**
  * Start the livereload server
@@ -91,7 +91,7 @@ exports.listen = function(opts, cb) {
   }
 
   options = _assign(options, opts);
-  exports.server = new tinylr.Server(options);
+  exports.server = new minilr.Server(options);
   exports.server.listen(options.port, options.host, function() {
     debug('now listening on port %d', options.port);
     if(typeof cb === 'function') cb.apply(exports.server, arguments);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "event-stream": "^3.1.7",
     "gulp-util": "^3.0.2",
     "lodash.assign": "^3.0.0",
-    "tiny-lr": "^0.1.5"
+    "mini-lr": "^0.1.8"
   },
   "devDependencies": {
     "mocha": "^2.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
 
 var gutil = require('gulp-util');
 var es = require('event-stream');
-var tinylr = require('tiny-lr');
+var minilr = require('mini-lr');
 var glr = require('../index.js');
 var sinon = require('sinon');
 var assert = require('assert');
@@ -14,7 +14,7 @@ var srv, log;
 
 describe('gulp-livereload', function() {
   beforeEach(function() {
-    srv = sinon.stub(tinylr, 'Server');
+    srv = sinon.stub(minilr, 'Server');
     log = sinon.stub(gutil, 'log');
   });
   afterEach(function() {


### PR DESCRIPTION
Fixes #94

The tiny-lr project has seemingly been abandoned and no new release has been cut for months to provide the support for npm v3. As such, I've forked the project and released mini-lr moving forward.

More Info: https://github.com/mklabs/tiny-lr/issues/91