### PR TITLE
Update minimum supported Node version to Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - '0.10'
-  - '0.12'
-  - '4'
+  # Support policy: Maintained Node versions.
+  - '6'
+  - '8'
+  - '10'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "gulpplugin",
     "livereload"
   ],
+  "engines": {
+    "node": ">=6"
+  },
   "dependencies": {
     "chalk": "^0.5.1",
     "debug": "^2.1.0",


### PR DESCRIPTION
This commit defines the support policy of `gulp-livereload`. This plugin targets officially maintained Node versions. It currently covers the versions 6, 8, and 10.