### PR TITLE
Replace `mini-lr` dependency by `tiny-lr`

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var es = require('event-stream');
 var log = require('fancy-log');
-var minilr = require('mini-lr');
+var tinyLr = require('tiny-lr');
 var relative = require('path').relative;
 var _assign = require('lodash.assign');
 var debug = require('debug')('gulp:livereload');
@@ -63,7 +63,7 @@ exports.server = undefined;
  * A direct reference to the underlying servers middleware reference
  */
 
-exports.middleware = minilr.middleware;
+exports.middleware = tinyLr.middleware;
 
 /**
  * Start the livereload server
@@ -91,7 +91,7 @@ exports.listen = function(opts, cb) {
   }
 
   options = _assign(options, opts);
-  exports.server = new minilr.Server(options);
+  exports.server = new tinyLr.Server(options);
   exports.server.listen(options.port, options.host, function() {
     debug('now listening on port %d', options.port);
     if(typeof cb === 'function') cb.apply(exports.server, arguments);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "event-stream": "^3.1.7",
     "fancy-log": "^1.3.2",
     "lodash.assign": "^3.0.0",
-    "mini-lr": "^0.1.8",
+    "tiny-lr": "^1.1.1",
     "vinyl": "^2.1.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var es = require('event-stream');
 var path = require('path');
 var sinon = require('sinon');
-var minilr = require('mini-lr');
+var tinyLr = require('tiny-lr');
 var Vinyl = require('vinyl');
 var glr = require('../index.js');
 var fancyLog = {log: require('fancy-log')};
@@ -16,7 +16,7 @@ var srv, log;
 
 describe('gulp-livereload', function() {
   beforeEach(function() {
-    srv = sinon.stub(minilr, 'Server');
+    srv = sinon.stub(tinyLr, 'Server');
     log = sinon.stub(fancyLog, "log");
   });
   afterEach(function() {


### PR DESCRIPTION
`mini-lr` is no longer maintained. This commit replaces it by `tiny-lr`, a drop-in replacement.