### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
     "node": ">=6"
   },
   "dependencies": {
-    "chalk": "^0.5.1",
-    "debug": "^2.1.0",
-    "event-stream": "^3.1.7",
+    "chalk": "^2.4.1",
+    "debug": "^3.1.0",
+    "event-stream": "^3.3.4",
     "fancy-log": "^1.3.2",
-    "lodash.assign": "^3.0.0",
+    "lodash.assign": "^4.2.0",
     "tiny-lr": "^1.1.1",
-    "vinyl": "^2.1.0"
+    "vinyl": "^2.2.0"
   },
   "devDependencies": {
-    "mocha": "^2.0.1",
-    "sinon": "^1.12.2"
+    "mocha": "^5.2.0",
+    "sinon": "^6.1.5"
   }
 }


### PR DESCRIPTION
Closes vohof/gulp-livereload#131

This is a follow-up to https://github.com/vohof/gulp-livereload/pull/132.